### PR TITLE
Reorder infobloxnios headers

### DIFF
--- a/devices/infobloxnios/infobloxniosmsg.xml
+++ b/devices/infobloxnios/infobloxniosmsg.xml
@@ -10,14 +10,14 @@
 		device="2.0" />
 	
 <HEADER
+	id1="001"
+	id2="001"
+	content="&lt;month&gt; &lt;day&gt; &lt;time&gt; &lt;hhostname&gt; &lt;messageid&gt;[&lt;data&gt;]: &lt;!payload&gt;"		/>
+<HEADER
 	id1="006"
 	id2="006"
 	content="&lt;month&gt; &lt;day&gt; &lt;time&gt; &lt;hhostname&gt; {&lt;hhostip&gt;&lt;messageid&gt;[&lt;data&gt;]|&lt;hhostip&gt;&lt;messageid&gt;}: &lt;!payload&gt;"/>
 
-<HEADER
-	id1="001"
-	id2="001"
-	content="&lt;month&gt; &lt;day&gt; &lt;time&gt; &lt;hhostname&gt; &lt;messageid&gt;[&lt;data&gt;]: &lt;!payload&gt;"		/>
 <HEADER
 	id1="005"
 	id2="005"

--- a/release.sh
+++ b/release.sh
@@ -145,7 +145,7 @@ test_fileset() {
         TESTING_FILEBEAT_MODULES=$MOD                \
         TESTING_FILEBEAT_FILESETS=$FST               \
         GENERATE=1                                   \
-        nosetests -v -s tests/system/test_xpack_modules.py || die "Generating golden files failed"
+        pytest -v -s tests/system/test_xpack_modules.py || die "Generating golden files failed"
 
     echo ""
     echo "Testing $MOD/$FST [$LINE/$LINES]"
@@ -153,7 +153,7 @@ test_fileset() {
         INTEGRATION_TESTS=1                          \
         TESTING_FILEBEAT_MODULES=$MOD                \
         TESTING_FILEBEAT_FILESETS=$FST               \
-        nosetests -v -s tests/system/test_xpack_modules.py || die "Generating golden files failed"
+        pytest -v -s tests/system/test_xpack_modules.py || die "Generating golden files failed"
 
     popd
 }


### PR DESCRIPTION
Re-order syslog header parsers so that the first header doesn't contribute to parsing errors.