### PR TITLE
Update ECS version to 1.8.0

### DIFF
--- a/layout/module/__module__/__fileset__/config/input.yml.tpl
+++ b/layout/module/__module__/__fileset__/config/input.yml.tpl
@@ -76,4 +76,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/layout/package/__module__/data_stream/__fileset__/agent/stream/stream.yml.hbs.tpl
+++ b/layout/package/__module__/data_stream/__fileset__/agent/stream/stream.yml.hbs.tpl
@@ -68,4 +68,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/layout/package/__module__/data_stream/__fileset__/agent/stream/tcp.yml.hbs.tpl
+++ b/layout/package/__module__/data_stream/__fileset__/agent/stream/tcp.yml.hbs.tpl
@@ -65,4 +65,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0

--- a/layout/package/__module__/data_stream/__fileset__/agent/stream/udp.yml.hbs.tpl
+++ b/layout/package/__module__/data_stream/__fileset__/agent/stream/udp.yml.hbs.tpl
@@ -65,4 +65,4 @@ processors:
 - add_fields:
     target: ''
     fields:
-        ecs.version: 1.7.0
+        ecs.version: 1.8.0


### PR DESCRIPTION
This just updates the `ecs.version` field set by modules / packages.

There is no changes to be made to the parsers as there is no information for multiuser events or (currently) category mappings.