### PR TITLE
Sophos UTM (astarosg): Fix header order

### DIFF
--- a/devices/astarosg/astarosgmsg.xml
+++ b/devices/astarosg/astarosgmsg.xml
@@ -19,13 +19,12 @@
 <HEADER
 	id1="0001"
 	id2="0001"
-	content="&lt;hfld1&gt;  &lt;messageid&gt;[&lt;process_id&gt;]: &lt;!payload&gt;"/>
-		
-	
+	content="&lt;hfld1&gt; &lt;hostname&gt; &lt;messageid&gt;[&lt;process_id&gt;]: &lt;!payload&gt;"/>
+
 <HEADER
 	id1="0002"
 	id2="0002"
-	content="&lt;hfld1&gt; &lt;hostname&gt; &lt;messageid&gt;[&lt;process_id&gt;]: &lt;!payload&gt;"/>
+	content="&lt;hfld1&gt;  &lt;messageid&gt;[&lt;process_id&gt;]: &lt;!payload&gt;"/>
 	
 <HEADER
 	id1="0003"


### PR DESCRIPTION
Wrong header order prevents parsing syslog messages that include a hostname.